### PR TITLE
add rake task to disable all otps

### DIFF
--- a/app/workers/reset_otp_worker.rb
+++ b/app/workers/reset_otp_worker.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ResetOtpWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'pull', lock: :until_executed, lock_ttl: 1.week.to_i
+
+  def perform(user_id, options = {})
+    user = User.find(user_id)
+
+    user.disable_two_factor!
+  rescue ActiveRecord::RecordNotFound
+    true
+  end
+end

--- a/lib/tasks/theatl-social.rake
+++ b/lib/tasks/theatl-social.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+task stats: 'theatl_social:reset_otp'
+
+namespace :theatl_social do
+  desc 'Removes all otps from users. Run with caution'
+  task :reset_otp, [:dry_run] => :environment do |t, args|
+    user_ids = User.where.not(otp_secret: nil).pluck(:id)
+    if args[:dry_run]
+      puts user_ids.count
+    else
+      user_ids.each do |id|
+        ResetOtpWorker.perform_async(id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Due to an encryption problem we need to reset otps for all users. This rake task will allow you to do that in a quick and efficient way.

From the mastodon-web container run `bundle exec rake theatl_social:reset_otps` Which will fetch all user ids of users who have an `otp_secret` set, and remove them.

Optionally run `bundle exec rake theatl_social:reset_otps[true]` to do a dry run. This will fetch all user ids that have an `otp_secret` set, and then display a count. This allows you to see how many users will be affected by this issue.

Each user will kick of a sidekiq job, just in case there are a lot of users with `otp_secrets`